### PR TITLE
httputil: add ChainFrom helper for middleware

### DIFF
--- a/httputil/middleware.go
+++ b/httputil/middleware.go
@@ -26,6 +26,14 @@ func Chain(outer Middleware, others ...Middleware) Middleware {
 	}
 }
 
+// ChainFrom wraps an HTTP Handler with the provided Middlewares.
+func ChainFrom(h http.Handler, m ...Middleware) http.Handler {
+	if len(m) > 0 {
+		return Chain(m[0], m[1:]...)(h)
+	}
+	return h
+}
+
 // HTTPDebugMiddleware is a Middleware which prints the HTTP request and response to out.
 // Use os.Stdout to print to standard out.
 // If printBody is false, only the HTTP headers are printed.

--- a/httputil/middleware_example_test.go
+++ b/httputil/middleware_example_test.go
@@ -28,6 +28,26 @@ func ExampleChain() {
 	// annotate:  three
 }
 
+func ExampleChainFrom() {
+	h := httputil.ChainFrom(myHandler(),
+		annotate("one"),
+		annotate("two"),
+		annotate("three"),
+	)
+
+	srv := httptest.NewServer(h)
+	defer srv.Close()
+
+	if _, err := http.Get(srv.URL); err != nil {
+		panic(err)
+	}
+
+	// Output:
+	// annotate:  one
+	// annotate:  two
+	// annotate:  three
+}
+
 func annotate(s string) httputil.Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
ChainFrom wraps an HTTP Handler with middleware.
ChainFrom is exactly like Chain, but it makes usage a little clearer.

When using Chain, the handler has to be passed like so:

	handler = Chain(mw1, mw2)(handler)

With ChainFrom, the same handler is wrapped with:

	handler = ChainFrom(handler, mw1, mw2)