### PR TITLE
Add http-01 support to the Let's Encrypt mechanism.

### DIFF
--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -267,16 +267,18 @@ func ListenAndServe(opts ...Option) error {
 			errs <- (&http.Server{
 				ReadTimeout:  5 * time.Second,
 				WriteTimeout: 5 * time.Second,
-				Handler: http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-					w.Header().Set("Connection", "close")
-					url := "https://" + req.Host + req.URL.String()
-					http.Redirect(w, req, url, http.StatusMovedPermanently)
-				}),
+				Handler:      m.HTTPHandler(http.HandlerFunc(redirect)),
 			}).ListenAndServe()
 		}()
 	}
 
 	return <-errs
+}
+
+func redirect(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Connection", "close")
+	url := "https://" + req.Host + req.URL.String()
+	http.Redirect(w, req, url, http.StatusMovedPermanently)
 }
 
 // tlsProfile represents a collection of TLS CipherSuites and their compatibility with Web Browsers.

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -262,7 +262,7 @@ func ListenAndServe(opts ...Option) error {
 		errs <- server.Serve(ln)
 	}()
 
-	if redirectHTTPS {
+	if redirectHTTPS || config.TLSConfig.GetCertificate != nil {
 		go func() {
 			errs <- (&http.Server{
 				ReadTimeout:  5 * time.Second,


### PR DESCRIPTION
Since the autocert.Manager is always created regardless of whether
Let's Encrypt is being used or not I opted to always wrap the HTTP
redirect handler with the autocert.Manager HTTPHandler. This means
that port 80 will always be available to handle a Let's Encrypt challenge
as well as do the redirect. This should get Let's Encrypt support
functioning again since tls-sni-02 and tls-sni-01 were deprecated.

Fixes https://github.com/micromdm/micromdm/issues/408

Testing this was a little bit of a pain but here's the process I followed.

* Spun up a new EC2 instance (or really anything with a public IP would work)
* Put a build of micromdm with these changes on the server
* Created a public DNS entry to point to the public EC2 server
* Ran micromdm as follows `sudo ./build/darwin/micromdm serve --server-url https://mydomain`
* Tried accessing https://mydomain in a web browser

The result was no errors like mentioned in  https://github.com/micromdm/micromdm/issues/408 and I could view the certificate from the http response and it was indeed one issued by lets encrypt.