### PR TITLE
Update httputil to use acmev2 and support tls-alpn-01

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.15
 
 require (
 	github.com/go-kit/kit v0.5.0
-	github.com/go-logfmt/logfmt v0.3.0
-	github.com/go-stack/stack v1.6.0
-	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
+	github.com/go-logfmt/logfmt v0.3.0 // indirect
+	github.com/go-stack/stack v1.6.0 // indirect
+	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
 	github.com/pkg/errors v0.8.0
 	golang.org/x/crypto v0.0.0-20170726172732-2faea1465de2
 )

--- a/go.mod
+++ b/go.mod
@@ -8,5 +8,5 @@ require (
 	github.com/go-stack/stack v1.6.0 // indirect
 	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
 	github.com/pkg/errors v0.8.0
-	golang.org/x/crypto v0.0.0-20170726172732-2faea1465de2
+	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 )

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.15
 
 require (
 	github.com/go-kit/kit v0.5.0
-	github.com/go-logfmt/logfmt v0.3.0 // indirect
-	github.com/go-stack/stack v1.6.0 // indirect
-	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 // indirect
+	github.com/go-logfmt/logfmt v0.3.0
+	github.com/go-stack/stack v1.6.0
+	github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
 	github.com/pkg/errors v0.8.0
 	golang.org/x/crypto v0.0.0-20170726172732-2faea1465de2
 )

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,12 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515 h1:T+h1c/A9Gawja4Y9mFVWj
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-golang.org/x/crypto v0.0.0-20170726172732-2faea1465de2 h1:g6Jk4NCbzVkE3QuoK7kz473R9aNOK08MoQSXry36ab4=
-golang.org/x/crypto v0.0.0-20170726172732-2faea1465de2/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -160,7 +160,7 @@ func ListenAndServe(opts ...Option) error {
 	}
 	config.TLSConfig = &tls.Config{
 		PreferServerCipherSuites: true,
-		NextProtos:               []string{"h2", "http/1.1"},
+		NextProtos:               []string{"h2", "http/1.1", acme.ALPNProto},
 	}
 	setProfile(config.TLSConfig, modern)
 


### PR DESCRIPTION
This updates httputil to use the latest version of autocert with acmev2 support and tls-alpn-01 challenge. This is stacked on top of #13 