### PR TITLE
Write recorded status code in debug middleware

### DIFF
--- a/httputil/middleware.go
+++ b/httputil/middleware.go
@@ -59,6 +59,10 @@ func HTTPDebugMiddleware(out io.Writer, printBody bool, logger func(...interface
 				}
 			}
 
+			if recorder.Code != 0 {
+				w.WriteHeader(recorder.Code)
+			}
+
 			buf := new(bytes.Buffer)
 			recorder.Body.WriteTo(io.MultiWriter(w, buf))
 			recorder.Body = buf


### PR DESCRIPTION
This fixes #7 as well as [MicroMDM's #406](https://github.com/micromdm/micromdm/issues/406).

This change just writes the recorded response code to the ResponseWriter. If a code wasn't written (so recorder.Code == 0), it doesn't write anything ("copying" the implicit HTTP 200 OK).