### PR TITLE
Allow configuring a listener on :443 without starting a redirect listener on :80

### DIFF
--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -61,6 +61,11 @@ func WithAddress(addr string) Option {
 	return func(c *serverConfig) { c.Addr = addr }
 }
 
+// WithAllowRedirectHTTPS configures whether a listener will be started on :80 to redirect requests to :443
+func WithAllowRedirectHTTPS(allow bool) Option {
+	return func(c *serverConfig) { c.allowRedirectHTTPS = allow }
+}
+
 // WithLogger provides a logger for ListenAndServe.
 // Not to be confused with an HTTP Logging Middleware for the HTTP Handler itself.
 func WithLogger(logger log.Logger) Option {
@@ -104,6 +109,9 @@ type serverConfig struct {
 
 	// Enforce a Strict Trasport Security (HSTS) Header for all HTTPS Connections.
 	hsts bool
+
+	// Start a listener on :80 to redirect to :443
+	allowRedirectHTTPS bool
 
 	logger log.Logger
 }
@@ -153,10 +161,11 @@ func Simple(
 // Let's Encrypt to manage the server certificate.
 func ListenAndServe(opts ...Option) error {
 	config := &serverConfig{
-		Addr:    ":https",
-		Handler: http.DefaultServeMux,
-		hsts:    true,
-		logger:  log.NewNopLogger(),
+		Addr:               ":https",
+		Handler:            http.DefaultServeMux,
+		hsts:               true,
+		allowRedirectHTTPS: true,
+		logger:             log.NewNopLogger(),
 	}
 	config.TLSConfig = &tls.Config{
 		PreferServerCipherSuites: true,
@@ -262,7 +271,7 @@ func ListenAndServe(opts ...Option) error {
 		errs <- server.Serve(ln)
 	}()
 
-	if redirectHTTPS {
+	if redirectHTTPS && config.allowRedirectHTTPS {
 		go func() {
 			errs <- (&http.Server{
 				ReadTimeout:  5 * time.Second,


### PR DESCRIPTION
Fix for https://github.com/micromdm/micromdm/issues/963